### PR TITLE
Allow digits in JSX attribute names

### DIFF
--- a/grammars/JavaScript (JSX).cson
+++ b/grammars/JavaScript (JSX).cson
@@ -630,7 +630,7 @@
 
     "jsx-tag-attribute-name":
       name: "meta.tag.attribute-name.js"
-      match: "\\b([a-zA-Z\\-:]+)"
+      match: "\\b([a-zA-Z0-9\\-:]+)"
       captures:
         1:
           name: "entity.other.attribute-name.js"


### PR DESCRIPTION
It is valid JSX to have an attribute with a digit like:

```
<example attr1="..." />
```

This diff adds digit support to the regex.
