### PR TITLE
Change "React" to "react" in Snippet for compatibity

### DIFF
--- a/snippets/JavaScript (JSX).cson
+++ b/snippets/JavaScript (JSX).cson
@@ -58,7 +58,7 @@
 
   "React: component skeleton":
     prefix: "rcc"
-    body: "/**\n * @jsx React.DOM\n */\n\nvar React = require('React');\n\nvar ${1} = React.createClass({\n\n\trender: function() {\n\t\treturn (\n\t\t\t${0:<div />}\n\t\t);\n\t}\n\n});\n\nmodule.exports = ${1};\n"
+    body: "/**\n * @jsx React.DOM\n */\n\nvar React = require('react');\n\nvar ${1} = React.createClass({\n\n\trender: function() {\n\t\treturn (\n\t\t\t${0:<div />}\n\t\t);\n\t}\n\n});\n\nmodule.exports = ${1};\n"
 
   "React: render: fn() { return ... }":
     prefix: "ren"


### PR DESCRIPTION
In the React component skeleton, using "React" with an upper-case "R" caused me problems on case-sensitive filesystems (like Heroku).
