### PR TITLE
Assume js files which require react are JSX

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -74,10 +74,8 @@ class AtomReact
     @patchEditorLangModeAutoDecreaseIndentForBufferRow(editor)?.jsxPatch = true
 
   isJSX: (text) ->
-    docblock = require 'jstransform/src/docblock'
-    doc = docblock.parse text;
-    for b in doc
-      return true if b[0] == 'jsx'
+    # assume if react is required that the file is implicitly JSX
+    return true if (text.indexOf("require('react") != -1 || text.indexOf('require("react') != -1)
     false
 
   isReactEnabledForEditor: (editor) ->


### PR DESCRIPTION
This is kind of a hacky solution but I wanted to throw it out there for discussion.  Many people use .js as the extension for their jsx files, and many (most?) use JSX when using react.  In my case the easiest (implicit) way to detect if I want the file treated as JSX is if react is required.  

Moreover since this package is targeted specifically at react and not JSX in general, it makes sense to test specifically for react rather than test for JSX (in .js files)

Thoughts?