### PR TITLE
get rid of deprecation warning about renderComponent() React-0.12+

### DIFF
--- a/snippets/JavaScript (JSX).cson
+++ b/snippets/JavaScript (JSX).cson
@@ -82,5 +82,5 @@
 
   "React: renderComponent(component, container, [callback])":
     prefix: "rrc"
-    body: "React.renderComponent(${1:<$2 />}, ${3:document.body}${4:, ${5:callback}});"
+    body: "React.render(${1:<$2 />}, ${3:document.body}${4:, ${5:callback}});"
 }


### PR DESCRIPTION
get rid of:
"Warning: React.renderComponent will be deprecated in a future version. Use React.render instead."
http://facebook.github.io/react/blog/2014/10/28/react-v0.12.html#deprecations
