### PR TITLE
Extend create class snippet with PropTypes import

### DIFF
--- a/snippets/JavaScript (JSX).cson
+++ b/snippets/JavaScript (JSX).cson
@@ -50,7 +50,7 @@
 
   "React: component skeleton":
     prefix: "rcc"
-    body: "var React = require('react');\n\nvar ${1} = React.createClass({\n\n\trender: function() {\n\t\treturn (\n\t\t\t${0:<div />}\n\t\t);\n\t}\n\n});\n\nmodule.exports = ${1};"
+    body: "var React = require('react');\nvar PropTypes = React.PropTypes;\n\nvar ${1} = React.createClass({\n\n\trender: function() {\n\t\treturn (\n\t\t\t${0:<div />}\n\t\t);\n\t}\n\n});\n\nmodule.exports = ${1};"
 
   "React: render: fn() { return ... }":
     prefix: "ren"
@@ -114,11 +114,11 @@
 
   "React: class skeleton":
     prefix: "rcd"
-    body: "import React from 'react'\n\nclass $1 extends React.Component {\n\trender () {\n\t\n\t}\n}\n\nexport default ${1};"
+    body: "import React, { PropTypes } from 'react'\n\nclass $1 extends React.Component {\n\trender () {\n\t\n\t}\n}\n\nexport default ${1};"
 
   "React: component skeleton (ES6)":
     prefix: "rcc6"
-    body: "import React from \'react\'\n\nconst $1 = React.createClass({\n\trender () {\n\t\treturn (\n\t\n\t\t)\n\t}\n})\n\nexport default ${1}\n"
+    body: "import React, { PropTypes } from \'react\'\n\nconst $1 = React.createClass({\n\trender () {\n\t\treturn (\n\t\n\t\t)\n\t}\n})\n\nexport default ${1}\n"
 
   "React: render() { return ... } (ES6)":
     prefix: "ren6"


### PR DESCRIPTION
In a last year its become de facto standard to validate the props of React Component. Also [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) support `prop-types` rule to enforce developer define props validation.
The common `React`import case in es6 world is:
```js
import React, { PropTypes } from 'react'
```
This PR extends `rcc`, `rcc6` and `rcd` snippets with `PropTypes` import.
