### PR TITLE
detect files with es6 destructuring imports

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -1,7 +1,7 @@
 {CompositeDisposable, Disposable} = require 'atom'
 
 contentCheckRegex = null
-defaultDetectReactFilePattern = '/((require\\([\'"]react(?:(-native|\\/addons))?[\'"]\\)))|(import\\s+\\w+\\s+from\\s+[\'"]react(?:(-native|\\/addons))?[\'"])/'
+defaultDetectReactFilePattern = '/((require\\([\'"]react(?:(-native|\\/addons))?[\'"]\\)))|(import\\s+[\\w{},\\s]+\\s+from\\s+[\'"]react(?:(-native|\\/addons))?[\'"])/'
 autoCompleteTagStartRegex = /(<)([a-zA-Z0-9\.:$_]+)/g
 autoCompleteTagCloseRegex = /(<\/)([^>]+)(>)/g
 

--- a/spec/fixtures/sample-correct-addons-es6.js
+++ b/spec/fixtures/sample-correct-addons-es6.js
@@ -1,1 +1,1 @@
-import React from 'react/addons'; // import react
+import React, { Component, PropTypes } from 'react/addons'; // import react

--- a/spec/fixtures/sample-correct-es6.js
+++ b/spec/fixtures/sample-correct-es6.js
@@ -1,1 +1,1 @@
-import React from 'react'; // import react
+import React, { Component, PropTypes } from 'react'; // import react


### PR DESCRIPTION
Properly detect react files with ES6 destructuring imports. Fixes #69
and #79.