### PR TITLE
Fix JSX highlight in parens after a keyword. #148

### DIFF
--- a/grammars/JavaScript (JSX).cson
+++ b/grammars/JavaScript (JSX).cson
@@ -12,8 +12,22 @@
     'include': '#jsx'
   }
   {
-    'match': '(?<!\\.)\\b(await|break|case|catch|continue|do|else|finally|for|if|import|from|package|return|switch|throw|try|while|with)(?!\\s*:)\\b'
-    'name': 'keyword.control.js'
+    'comment': 'Fix issue that caused some keywords to appear as func calls. https://github.com/orktes/atom-react/issues/138 https://github.com/orktes/atom-react/issues/148'
+    'begin': '(?<!\\.)\\b(await|break|case|catch|continue|do|else|finally|for|if|import|from|package|return|switch|throw|try|while|with)(?!\\s*:)\\b\\s*(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.control.js'
+      '2':
+        'name': 'meta.brace.round.js'
+    'end': '(\\))'
+    'endCaptures':
+      '1':
+        'name': 'meta.brace.round.js'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
   }
   {
     'include': '#method_call'

--- a/spec/react-grammar-spec.coffee
+++ b/spec/react-grammar-spec.coffee
@@ -72,7 +72,7 @@ describe "React grammar", ->
 
       {tokens} = grammar.tokenizeLine('[1, /test/]')
       expect(tokens[0]).toEqual value: '[', scopes: ['source.js.jsx', 'meta.brace.square.js']
-      expect(tokens[1]).toEqual value: '1', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[1]).toEqual value: '1', scopes: ['source.js.jsx', 'constant.numeric.decimal.js']
       expect(tokens[2]).toEqual value: ',', scopes: ['source.js.jsx', 'meta.delimiter.object.comma.js']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js.jsx', 'string.regexp.js']
       expect(tokens[4]).toEqual value: '/', scopes: ['source.js.jsx', 'string.regexp.js', 'punctuation.definition.string.begin.js']
@@ -81,22 +81,22 @@ describe "React grammar", ->
       expect(tokens[7]).toEqual value: ']', scopes: ['source.js.jsx', 'meta.brace.square.js']
 
       {tokens} = grammar.tokenizeLine('0x1D306')
-      expect(tokens[0]).toEqual value: '0x1D306', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0x1D306', scopes: ['source.js.jsx', 'constant.numeric.hex.js']
 
       {tokens} = grammar.tokenizeLine('0X1D306')
-      expect(tokens[0]).toEqual value: '0X1D306', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0X1D306', scopes: ['source.js.jsx', 'constant.numeric.hex.js']
 
       {tokens} = grammar.tokenizeLine('0b011101110111010001100110')
-      expect(tokens[0]).toEqual value: '0b011101110111010001100110', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0b011101110111010001100110', scopes: ['source.js.jsx', 'constant.numeric.binary.js']
 
       {tokens} = grammar.tokenizeLine('0B011101110111010001100110')
-      expect(tokens[0]).toEqual value: '0B011101110111010001100110', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0B011101110111010001100110', scopes: ['source.js.jsx', 'constant.numeric.binary.js']
 
       {tokens} = grammar.tokenizeLine('0o1411')
-      expect(tokens[0]).toEqual value: '0o1411', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0o1411', scopes: ['source.js.jsx', 'constant.numeric.octal.js']
 
       {tokens} = grammar.tokenizeLine('0O1411')
-      expect(tokens[0]).toEqual value: '0O1411', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: '0O1411', scopes: ['source.js.jsx', 'constant.numeric.octal.js']
 
   describe "operators", ->
     it "tokenizes void correctly", ->
@@ -108,10 +108,10 @@ describe "React grammar", ->
         1
         / 2
       """
-      expect(lines[0][0]).toEqual value: '1', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(lines[0][0]).toEqual value: '1', scopes: ['source.js.jsx', 'constant.numeric.decimal.js']
       expect(lines[1][0]).toEqual value: '/', scopes: ['source.js.jsx', 'keyword.operator.js']
       expect(lines[1][1]).toEqual value: ' ', scopes: ['source.js.jsx']
-      expect(lines[1][2]).toEqual value: '2', scopes: ['source.js.jsx', 'constant.numeric.js']
+      expect(lines[1][2]).toEqual value: '2', scopes: ['source.js.jsx', 'constant.numeric.decimal.js']
 
   describe "ES6 string templates", ->
     it "tokenizes them as strings", ->
@@ -191,6 +191,28 @@ describe "React grammar", ->
     #expect(tokens[4]).toEqual value: '</', scopes: ["source.js.jsx","tag.closed.js","punctuation.definition.tag.begin.js"]
     #expect(tokens[5]).toEqual value: 'tag', scopes: ["source.js.jsx","tag.closed.js","entity.name.tag.js"]
     #expect(tokens[6]).toEqual value: '>', scopes: ["source.js.jsx","tag.closed.js","punctuation.definition.tag.end.js"]
+
+  it "tokenizes jsx tags inside parentheses after return", ->
+    lines = grammar.tokenizeLines """
+      return (
+        <tag></tag>
+      );
+    """
+
+    expect(lines[0][0]).toEqual value: 'return', scopes: ['source.js.jsx', 'keyword.control.js']
+    expect(lines[0][1]).toEqual value: ' ', scopes: ['source.js.jsx']
+    expect(lines[0][2]).toEqual value: '(', scopes: ['source.js.jsx', 'meta.brace.round.js']
+
+    expect(lines[1][0]).toEqual value: '  ', scopes: ['source.js.jsx']
+    expect(lines[1][1]).toEqual value: '<', scopes: ['source.js.jsx', 'tag.open.js', 'punctuation.definition.tag.begin.js']
+    expect(lines[1][2]).toEqual value: 'tag', scopes: ['source.js.jsx', 'tag.open.js', 'entity.name.tag.js']
+    expect(lines[1][3]).toEqual value: '>', scopes: ['source.js.jsx', 'tag.open.js', 'punctuation.definition.tag.end.js']
+    expect(lines[1][4]).toEqual value: '</', scopes: ['source.js.jsx', 'tag.closed.js', 'punctuation.definition.tag.begin.js']
+    expect(lines[1][5]).toEqual value: 'tag', scopes: ['source.js.jsx', 'tag.closed.js', 'entity.name.tag.js']
+    expect(lines[1][6]).toEqual value: '>', scopes: ['source.js.jsx', 'tag.closed.js', 'punctuation.definition.tag.end.js']
+
+    expect(lines[2][0]).toEqual value: ')', scopes: ['source.js.jsx', 'meta.brace.round.js']
+    expect(lines[2][1]).toEqual value: ';', scopes: ['source.js.jsx', 'punctuation.terminator.statement.js']
 
 
 


### PR DESCRIPTION
The match proposed in https://github.com/orktes/atom-react/commit/c267e8e376ed5832d488203f9c6cc102a4583279 somehow prevents the lines inside a pair of following parentheses from being parsed as JSX; the parser falls back to plain JS where angle brackets are highlighted as operators. This causes https://github.com/orktes/atom-react/issues/148

The match in this fix embraces the whole expression and instructs to parse its contents with nested patterns which include JSX.