### PR TITLE
Add default render component

### DIFF
--- a/snippets/JavaScript (JSX).cson
+++ b/snippets/JavaScript (JSX).cson
@@ -126,7 +126,7 @@
 
   "React: component skeleton (ES6)":
     prefix: "rcc6"
-    body: "import React, { PropTypes } from \'react\'\n\nconst $1 = React.createClass({\n\trender () {\n\t\treturn (\n\t\n\t\t)\n\t}\n})\n\nexport default ${1}\n"
+    body: "import React, { PropTypes } from \'react\'\n\nconst $1 = React.createClass({\n\trender () {\n\t\treturn (\n\t\t\t${2:<div />}\n\t\t)\n\t}\n})\n\nexport default ${1}\n"
 
   "React: stateless component (ES6)":
     prefix: "rcs"


### PR DESCRIPTION
Allows the user to directly edit the `render` component method, by changing its JSX returned value.

This would then follow the same `rcc` snippet behaviour.