### PR TITLE
fix autoclose tag newline insert

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -285,7 +285,7 @@ class AtomReact
             ]
           , '', {undo: 'skip'})
 
-    else if eventObj?.newText is '\n'
+    else if eventObj? and eventObj.newText.match /\r?\n/
       lines = editor.buffer.getLines()
       row = eventObj.newRange.end.row
       lastLine = lines[row - 1]


### PR DESCRIPTION
(really, easier to read the patch than the description :wink: )

On Windows, if you autocomplete tag and then press enter, the cursor will be at the < of the closing tag. On Mac/Linux, it instead inserts a blank line, indents it correctly, and leaves the cursor there.

The different behaviour is of course because Windows uses \r\n. This one-line change fixes that. (The behaviour, not the fact that Windows is weird.)