### PR TITLE
make undo-skipping optional for auto-close insertion/deletion

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -252,7 +252,7 @@ class AtomReact
           options = {undo: 'skip'}
         else
           options = {}
-        console.log options
+          
         editor.insertText('</' + tagName + '>', options)
         editor.setCursorBufferPosition(eventObj.newRange.end)
 


### PR DESCRIPTION
FIx #172.


This PR add config option.

- `skipUndoStackForAutoCloseInsertion`: default `true` to not break previous behavior.

When set to `false`, auto-close-tag insertion/deletion no longer **skip** undo stack of buffer change history.

## Background:

- I'm maintainer of vim-mode-plus package
- One of my user report `undo` do not correctly undo the all insertion.
- I investigated and found the cause is `undo: 'skip'` option.
- I understand the purpose, why you explicitly set this option.
- But vim's undo handling is a bit different, vim bundle all the changes made in `insert-mode` and undo all changes by single `undo`.
  - `atom-ract`'s default `undo: 'skip'` behavior is not well fit of this behavior.
  - So hope you consider to allow this undo-skipping optional.

https://github.com/t9md/atom-vim-mode-plus/issues/778#issuecomment-299860100

Thanks
