### PR TITLE
fix async arrow function with parens

### DIFF
--- a/grammars/JavaScript (JSX).cson
+++ b/grammars/JavaScript (JSX).cson
@@ -740,7 +740,7 @@
     'patterns': [
       {
         # functionCall(arg1, "arg2", [...])
-        'begin': '([\\w$]+)\\s*(?=\\()'
+        'begin': '(?!\\basync\\b)([\\w$]+)\\s*(?=\\()'
         'beginCaptures':
           '1':
             'patterns': [


### PR DESCRIPTION
I'm not sure this fixes the whole problem but it seems to work

This removes `async()` from the function call match so it can be seen as an async arrow function

fixes #231 