### PR TITLE
Support as embedded grammar

### DIFF
--- a/grammars/CoffeeScript (JSX).cson
+++ b/grammars/CoffeeScript (JSX).cson
@@ -1,5 +1,6 @@
 'name': 'CoffeeScript (JSX)'
 'scopeName': 'source.coffee.jsx'
+'injectionSelector': 'source.embedded.cjsx'
 'comment': 'Coffee-React Syntax'
 'fileTypes': [
   'cjsx'

--- a/grammars/JavaScript (JSX).cson
+++ b/grammars/JavaScript (JSX).cson
@@ -1,5 +1,6 @@
 'name': 'JavaScript (JSX)'
 'scopeName': 'source.js.jsx'
+'injectionSelector': 'source.embedded.jsx'
 'fileTypes': [
   'jsx',
   'react.js'


### PR DESCRIPTION
Adding the `injectionSelector` property allows this grammar to embed itself into others. Specifically, when the scope in a file is `source.embedded.jsx` (or cjsx). This occurs in something like `language-gfm`, where it tries to include the `source.embedded.<language_name>` grammar if none of the hardcoded values match.

E.g.,
````
```jsx
<jsx code>
```
````

Would be properly scoped with the rules defined here.