### PR TITLE
Fix builds and package load error for Atom 1.24

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -131,7 +131,7 @@ class AtomReact
     # Check if file extension is .jsx or the file requires React
     extName = path.extname(editor.getPath() or '')
     if extName is ".jsx" or ((extName is ".js" or extName is ".es6") and @isReact(editor.getText()))
-      jsxGrammar = atom.grammars.grammarsByScopeName["source.js.jsx"]
+      jsxGrammar = atom.grammars.grammarForScopeName("source.js.jsx")
       editor.setGrammar jsxGrammar if jsxGrammar
 
   onHTMLToJSX: ->

--- a/spec/atom-react-spec.coffee
+++ b/spec/atom-react-spec.coffee
@@ -13,8 +13,10 @@ describe "React tests", ->
     waitsForPromise ->
       atom.packages.activatePackage("react")
 
-    afterEach ->
+  afterEach ->
+    waitsForPromise ->
       atom.packages.deactivatePackages()
+    runs ->
       atom.packages.unloadPackages()
 
   describe "should select correct grammar", ->

--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -12,8 +12,10 @@ describe "Tag autocomplete tests", ->
           grammar = atom.grammars.grammarForScopeName("source.js.jsx")
           editor.setGrammar(grammar);
 
-    afterEach ->
+  afterEach ->
+    waitsForPromise ->
       atom.packages.deactivatePackages()
+    runs ->
       atom.packages.unloadPackages()
 
   describe "tag handling", ->

--- a/spec/react-grammar-spec.coffee
+++ b/spec/react-grammar-spec.coffee
@@ -16,12 +16,14 @@ describe "React grammar", ->
     waitsForPromise ->
       atom.packages.activatePackage("react")
 
-    afterEach ->
-      atom.packages.deactivatePackages()
-      atom.packages.unloadPackages()
-
     runs ->
       grammar = atom.grammars.grammarForScopeName("source.js.jsx")
+
+  afterEach ->
+    waitsForPromise ->
+      atom.packages.deactivatePackages()
+    runs ->
+      atom.packages.unloadPackages()
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()


### PR DESCRIPTION
This fixes the problem in #269 caused by a refactor of the `GrammarRegistry`. The refactor added shims for the documented public API of `FirstMate.GrammarRegistry` but the `grammarsByScopeName` property we were previously relying on wasn't part of that. Instead, we can use the getter method `grammarForScopeName` that made it through the refactor intact and the same code can work in either Atom version.