### PR TITLE
Add snippets include Error Boundary Component and Lazyload import.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "react",
+  "version": "0.18.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "esprima-fb": {
+      "version": "4001.3001.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-4001.3001.0-dev-harmony-fb.tgz",
+      "integrity": "sha1-ZZ8fXch/L0dNsjSn2yobbD5ArxQ="
+    },
+    "jsxformat": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/jsxformat/-/jsxformat-0.0.10.tgz",
+      "integrity": "sha1-0Dtt16nmtYxyO5u70FzRyIeiS8s=",
+      "requires": {
+        "lodash": "~2.4.1",
+        "rocambole": "git+https://github.com/millermedeiros/rocambole.git#1bd5044df1d6c888a1bd1b511158fb34b011e9aa",
+        "rocambole-token": "~1.2.1",
+        "underscore.string": "~2.4.0"
+      }
+    },
+    "lodash": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+    },
+    "rocambole": {
+      "version": "git+https://github.com/millermedeiros/rocambole.git#1bd5044df1d6c888a1bd1b511158fb34b011e9aa",
+      "from": "git+https://github.com/millermedeiros/rocambole.git#1bd5044df1d6c888a1bd1b511158fb34b011e9aa",
+      "requires": {
+        "esprima-fb": "^4001.3001.0-dev-harmony-fb"
+      }
+    },
+    "rocambole-token": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
+      "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU="
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+    }
+  }
+}

--- a/snippets/JavaScript (JSX).cson
+++ b/snippets/JavaScript (JSX).cson
@@ -8,6 +8,10 @@
     prefix: "imr"
     body: "import React from 'react';"
 
+  "React: import component with lazy load":
+    prefix: "imlazy"
+    body: "const $1 = React.lazy(() => import('${1}'));"
+
   "React: componentDidMount: fn() { ... }":
     prefix: "cdm"
     body: "componentDidMount: function() {\n\t${1}\n},"
@@ -15,6 +19,10 @@
   "React: componentDidUpdate: fn(pp, ps) { ... }":
     prefix: "cdup"
     body: "componentDidUpdate: function(prevProps, prevState) {\n\t${1}\n},"
+
+  "React: componentDidCatch: fn(error, info) { ... }":
+    prefix: "cdc"
+    body: "componentDidCatch: function(error, info) {\n\t${1}\n},"
 
   "React: componentWillMount: fn() { ... }":
     prefix: "cwm"
@@ -92,6 +100,10 @@
     prefix: "cdup6"
     body: "componentDidUpdate(prevProps, prevState) {\n\t${1}\n}"
 
+  "React: componentDidCatch(error, info) { ... } (ES6)":
+    prefix: "cdc6"
+    body: "componentDidCatch(error, info) {\n\t${1}\n}"
+
   "React: componentWillMount() { ... } (ES6)":
     prefix: "cwm6"
     body: "componentWillMount() {\n\t${1}\n}"
@@ -131,6 +143,10 @@
   "React: stateless component (ES6)":
     prefix: "rcs"
     body: "import React from \'react\'\nimport PropTypes from \'prop-types\'\n\nconst $1 = (${2:props}) => {\n\treturn (\n\t\t${3:<div />}\n\t)\n}\n\nexport default ${1}\n"
+
+  "React: error boundary skeleton (ES6)":
+    prefix: 'reb6'
+    body: "import React from 'react';\nimport PropTypes from 'prop-types';\n\nclass $1 extends React.Component {\n  constructor(props) {\n    super(props);\n    this.state = { hasError: false };\n  }\n\n  static getDerivedStateFromError(error) {\n    // Update state so the next render will show the fallback UI.\n    return { hasError: true };\n  }\n\n  componentDidCatch(error, info) {\n    // You can also log the error to an error reporting service\n  }\n\n  render() {\n    if (this.state.hasError) {\n      // You can render any custom fallback UI\n      return <h1>Something went wrong.</h1>;\n    }\n\n    return this.props.children; \n  }\n}\n\nexport default ${1};"
 
   "React: render() { return ... } (ES6)":
     prefix: "ren6"


### PR DESCRIPTION
New snippets added:
1) imlazy: React: import component with lazy load
2) cdc: React: componentDidCatch: fn(error, info) { ... }
3) cdc6: React: componentDidCatch(error, info) { ... } (ES6)
4) reb6: React: error boundary skeleton (ES6)