### PR TITLE
Fix indent for closing bracket (eslint rule react/jsx-closing-bracket-location)

### DIFF
--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -8,7 +8,7 @@ autoCompleteTagCloseRegex = /(<\/)([^>]+)(>)/g
 jsxTagStartPattern = '(?x)((^|=|return)\\s*<([^!/?](?!.+?(</.+?>))))'
 jsxComplexAttributePattern = '(?x)\\{ [^}"\']* $|\\( [^)"\']* $'
 decreaseIndentForNextLinePattern = '(?x)
-/>\\s*(,|;)?\\s*$
+\\S+\\s*/>\\s*(,|;)?\\s*$
 | ^(?!\\s*\\?)\\s*\\S+.*</[-_\\.A-Za-z0-9]+>$'
 
 class AtomReact
@@ -252,7 +252,7 @@ class AtomReact
           options = {undo: 'skip'}
         else
           options = {}
-          
+
         editor.insertText('</' + tagName + '>', options)
         editor.setCursorBufferPosition(eventObj.newRange.end)
 

--- a/settings/JavaScript (JSX).cson
+++ b/settings/JavaScript (JSX).cson
@@ -10,6 +10,7 @@
       | \\( [^)"\']* $'
     'decreaseIndentPattern': '(?x)
     ^\\s*(</[-_\\.A-Za-z0-9]+)
+    | ^\\s*/>\\s*(,|;)?\\s*$
     | ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]'
 
 '.source.js.jsx .tag:not(.entity.other.attribute-name, .entity.name.tag, .punctuation.definition.tag.begin, .invalid.illegal.incomplete .string, .curly)':


### PR DESCRIPTION
Follow eslint rule [react/jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md) [1] by decreasing indent for a lonely closing bracket and not doing so for its next line. Fixes #129, fixes #210, fixes #284.

If a multi-line element is self-closing, the closing bracket should be aligned with the opening bracket. And because of this, there's no need to decrease the indent on the next line (less so automatically each time one types anything).

For example, under the previous behaviour:
```javascript
<View>
  <Image
    source={...}
    style={{ width: 20 }}
    />
  <Text>Lorem ipsum</Text>
</View>
```

If one where to correct it manually, the next line would be problematic:
```javascript
<View>
  <Image
    source={...}
    style={{ width: 20 }}
  />
<Text>Lorem ipsum</Text>
</View>
```

New behaviour:
```javascript
<View>
  <Image
    source={...}
    style={{ width: 20 }}
  />
  <Text>Lorem ipsum</Text>
</View>
```

Checked for test regressions :heavy_check_mark: 

Previous fix in #131 was rollbacked.
**Anything i can help with so that this is merged, please tell me!**

[1] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md