### PR TITLE
React fragment shorthand syntax support

### DIFF
--- a/grammars/JavaScript (JSX).cson
+++ b/grammars/JavaScript (JSX).cson
@@ -484,7 +484,23 @@
         'name': 'punctuation.definition.tag.end.js'
   'jsx-tag-invalid':
     'name': 'invalid.illegal.tag.incomplete.js'
-    'match': '<\\s*>'
+    'match': '<\\s+>'
+  'jsx-tag-fragment-open':
+    'match': '(<)(>)'
+    'name': 'tag.open.js'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.js'
+      '2':
+        'name': 'punctuation.definition.tag.end.js'
+  'jsx-tag-fragment-close':
+    'match': '(</)(>)'
+    'name': 'tag.closed.js'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.js'
+      '2':
+        'name': 'punctuation.definition.tag.end.js'
   'jsx':
     'name': 'meta.jsx.js'
     'patterns': [
@@ -496,6 +512,12 @@
       }
       {
         'include': '#jsx-tag-invalid'
+      }
+      {
+        'include': '#jsx-tag-fragment-open'
+      }
+      {
+        'include': '#jsx-tag-fragment-close'
       }
     ]
   'docblock':

--- a/lib/atom-react.coffee
+++ b/lib/atom-react.coffee
@@ -2,8 +2,8 @@
 
 contentCheckRegex = null
 defaultDetectReactFilePattern = '/((require\\([\'"]react(?:(-native|\\/addons))?[\'"]\\)))|(import\\s+[\\w{},\\s]+\\s+from\\s+[\'"]react(?:(-native|\\/addons))?[\'"])/'
-autoCompleteTagStartRegex = /(<)([a-zA-Z0-9\.:$_]+)/g
-autoCompleteTagCloseRegex = /(<\/)([^>]+)(>)/g
+autoCompleteTagStartRegex = /(<)([a-zA-Z0-9\.:$_]*)/g
+autoCompleteTagCloseRegex = /(<\/)([^>]*)(>)/g
 
 jsxTagStartPattern = '(?x)((^|=|return)\\s*<([^!/?](?!.+?(</.+?>))))'
 jsxComplexAttributePattern = '(?x)\\{ [^}"\']* $|\\( [^)"\']* $'


### PR DESCRIPTION
This solves #258 by adding in support for fragment shorthand syntax.

```JSX
<>
    <p>Neat.</p>
</>
```

I've covered adding in the valid grammar as a separate regex check for tag opening and closing because things got weird when I tried to amend the existing tag open and close regex. Additionally I changed the regex in atom-react.coffee to allow auto-completion of fragments, which seems to have no adverse effects from my testing.

Unrelated to this package, bracket-matcher seems to be unable to properly highlight fragment tags due to them missing a tag name. This was the only side effect I noticed.